### PR TITLE
Double check using ref whether to call imperative dialog methods

### DIFF
--- a/src/lib/ModalDialog.jsx
+++ b/src/lib/ModalDialog.jsx
@@ -1,16 +1,22 @@
 import { useEffect, useRef } from "react";
 
 export default function ModalDialog({ isDialogVisible, children, closeDialog, dialogClassName, contentClassName }) {
-  const dialogRef = useRef(null);
-
+  const ref = useRef(null)
+  const shown = useRef(false)
   useEffect(() => {
-    const dialog = dialogRef.current;
     if (isDialogVisible) {
-      dialog.showModal();
+      if (!shown.current) {
+        ref.current.showModal()
+      }
+      shown.current = true
     } else {
-      dialog.close();
+      if (shown.current) {
+        ref.current.close()
+      }
+      shown.current = false
     }
-  }, [isDialogVisible]);
+  }, [isDialogVisible])
+
 
   const preventAutoClose = (e) => e.stopPropagation();
 


### PR DESCRIPTION
Thanks for this repo, I found it a useful reference. It is funny that the web api wants you to call the showModal rather than the open prop, but that is besides the point

I found, possibly related to the useEffect being called twice in strict mode, that it helps to add an extra useRef guard before calling the imperative dialog methods, otherwise i could get errors that were a bit odd saying that the open prop was already on the dialog even though i wasn't using the open prop at all

exact error

```
Uncaught DOMException: HTMLDialogElement.showModal: Dialog element already has an 'open' attribute
```